### PR TITLE
Add `skip_unknown` and `list_file` CLI args.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "ree-pak-cli"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/ree-pak-cli/Cargo.toml
+++ b/ree-pak-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ree-pak-cli"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 
 [dependencies]

--- a/ree-pak-cli/src/main.rs
+++ b/ree-pak-cli/src/main.rs
@@ -28,12 +28,18 @@ struct UnpackCommand {
     /// Output directory path
     #[clap(short, long)]
     output: Option<String>,
+    /// List file to use; overrides the project arg
+    #[clap(short, long)]
+    list_file: Option<String>,
     /// Ignore errors during unpacking files
     #[clap(long, default_value = "false")]
     ignore_error: bool,
     /// Override existing files
     #[clap(long, default_value = "false")]
     r#override: bool,
+    /// Skip files with an unknown path while unpacking
+    #[clap(long, default_value = "false")]
+    r#skip_unknown: bool,
 }
 
 #[derive(Debug, Args)]
@@ -47,6 +53,9 @@ struct DumpInfoCommand {
     /// Output file path
     #[clap(short, long)]
     output: Option<String>,
+    /// List file to use; overrides the project arg
+    #[clap(short, long)]
+    list_file: Option<String>,
     /// Override existing files
     #[clap(long, default_value = "false")]
     r#override: bool,

--- a/ree-pak-cli/src/main.rs
+++ b/ree-pak-cli/src/main.rs
@@ -19,7 +19,7 @@ enum Command {
 
 #[derive(Debug, Args)]
 struct UnpackCommand {
-    /// Game project name, e.g. "MHRS_PC_Demo"
+    /// Game project name or list file path, e.g. "MHRS_PC_Demo", "./MHRS_PC_Demo.list"
     #[clap(short, long)]
     project: String,
     /// Input PAK file path
@@ -28,9 +28,6 @@ struct UnpackCommand {
     /// Output directory path
     #[clap(short, long)]
     output: Option<String>,
-    /// List file to use; overrides the project arg
-    #[clap(short, long)]
-    list_file: Option<String>,
     /// Ignore errors during unpacking files
     #[clap(long, default_value = "false")]
     ignore_error: bool,


### PR DESCRIPTION
Forgive my Rust, I'm rusty.

I wanted a way to use the CLI as a replacement to RETool, but it was missing the ability to specify a list file, and to skip unknowns, making it not work as a drop-in replacement.
So I figured I'd add them.

My example use case:
```bat
"R:\Code\ree-pak-rs\target\release\ree-pak-cli.exe" unpack ^
    --override ^
    --skip-unknown ^
    --project "" ^
    --list-file "V:\MHWilds\temp-stm.list" ^
    --input "O:\SteamLibrary\steamapps\common\MonsterHunterWildsBetatest\re_chunk_000.pak" ^
    --output "V:\MHWilds\re_chunk_000"
pause
```

Both are optional and should default to the same behavior as before their addition.